### PR TITLE
N-gram cosine similarity

### DIFF
--- a/lib/string/similarity.rb
+++ b/lib/string/similarity.rb
@@ -12,17 +12,18 @@ module String::Similarity
   #
   # @param str1 [String] first string
   # @param str2 [String] second string
+  # @param ngram [Int] how many characters at once to use
   # @return [Float] cosine similarity of the two arguments.
   #   - +1.0+ if the strings are identical
   #   - +0.0+ if the strings are completely different
   #   - +0.0+ if one of the strings is empty
-  def self.cosine(str1, str2)
+  def self.cosine(str1, str2, ngram: 1)
     return 1.0 if str1 == str2
     return 0.0 if str1.empty? || str2.empty?
 
     # convert both texts to vectors
-    v1 = vector(str1)
-    v2 = vector(str2)
+    v1 = vector(str1, ngram)
+    v2 = vector(str2, ngram)
 
     # calculate the dot product
     dot_product = dot(v1, v2)

--- a/lib/string/similarity.rb
+++ b/lib/string/similarity.rb
@@ -18,6 +18,8 @@ module String::Similarity
   #   - +0.0+ if the strings are completely different
   #   - +0.0+ if one of the strings is empty
   def self.cosine(str1, str2, ngram: 1)
+    raise ArgumentError.new('ngram should be >= 1') if ngram < 1
+
     return 1.0 if str1 == str2
     return 0.0 if str1.empty? || str2.empty?
 

--- a/lib/string/similarity.rb
+++ b/lib/string/similarity.rb
@@ -94,13 +94,32 @@ module String::Similarity
   end
 
   # create a vector from +str+
+  # keys have a special format:
+  #     '[left padding, right padding, "string"]'
   #
   # @example
-  #     v1 = vector('hello') # => {"h"=>1, "e"=>1, "l"=>2, "o"=>1}
-  #     v1["x"] # => 0
-  def self.vector(str)
+  #     v1 = vector('aba', 1) # => {'[0, 0, "a"]' => 2, '[0, 0, "b"]' => 1}
+  #     v1['[0, 0, "x"]'] # => 0
+  # @example
+  #     vector('abacaba', 2) # => {
+  #       #  '[1, 0, "a"]' => 1,
+  #       #  '[0, 0, "ab"]' => 2,
+  #       #  '[0, 0, "ba"]' => 2,
+  #       #  '[0, 0, "ac"]' => 1,
+  #       #  '[0, 1, "a"]' => 1
+  #       # }
+  def self.vector(str, ngram)
     v = Hash.new(0)
-    str.each_char { |c| v[c] += 1 }
+
+    ((1 - ngram)..(str.length - 1)).each do |i|
+      before = [-i, 0].max
+      after = [ngram - (str.length - i), 0].max
+      slice = str[[i, 0].max .. [i + ngram - 1, str.length - 1].min]
+      key = [before, after, slice].to_s
+
+      v[key] += 1
+    end
+
     v
   end
 

--- a/lib/string/similarity.rb
+++ b/lib/string/similarity.rb
@@ -107,6 +107,7 @@ module String::Similarity
   #       #  '[0, 0, "ab"]' => 2,
   #       #  '[0, 0, "ba"]' => 2,
   #       #  '[0, 0, "ac"]' => 1,
+  #       #  '[0, 0, "ca"]' => 1
   #       #  '[0, 1, "a"]' => 1
   #       # }
   def self.vector(str, ngram)

--- a/spec/string/similarity_spec.rb
+++ b/spec/string/similarity_spec.rb
@@ -54,6 +54,37 @@ RSpec.describe String::Similarity do
                  })
       end
     end
+
+    context 'with n-grams' do
+      it 'returns 1-gram similarity same as default' do
+        s1 = klass.cosine('foo', 'boo')
+        s2 = klass.cosine('foo', 'boo', ngram: 1)
+
+        expect(s1).to eq s2
+      end
+      it 'returns correct 2-gram similarity' do
+        # here _ is substitution for the pad symbol
+        # abc has bigrams: _a, ab, bc, c_
+        # abcacbc has bigrams: _a, ab, bc, ca, ac, cb, bc, c_
+
+        expect(klass.cosine('abc', 'abcacbc',
+                            ngram: 2)).to be_within(0.001).of(0.79)
+      end
+
+      it 'returns correct 3-gram similarity' do
+        # here _ is substitution for the pad symbol
+        # abc has bigrams: __a, _ab, abc, bc_, c__
+        # abcacbc has bigrams: __a, _ab, abc, bca, cac, acb, cbc, bc_, c__
+
+        expect(klass.cosine('abc', 'abcacbc',
+                            ngram: 3)).to be_within(0.001).of(0.745)
+      end
+
+      it 'raises if n is < 1' do
+        expect { klass.cosine('a', 'b',
+                              ngrams: 0) }.to raise_error(ArgumentError)
+      end
+    end
   end
 
   context '#levenshtein_distance' do

--- a/spec/string/similarity_spec.rb
+++ b/spec/string/similarity_spec.rb
@@ -31,6 +31,29 @@ RSpec.describe String::Similarity do
     it 'returns values <= 1.0' do
       expect(klass.cosine('foo', 'fooaf')).to be <= 1.00000
     end
+
+    context 'vector', :vector do
+      it 'returns 1-gram vectors' do
+        expect(klass.send(:vector, 'abacaba', 1))
+          .to eq({
+                   '[0, 0, "a"]' => 4,
+                   '[0, 0, "b"]' => 2,
+                   '[0, 0, "c"]' => 1
+                 })
+      end
+
+      it 'returns 2-gram vectors' do
+        expect(klass.send(:vector, 'abacaba', 2))
+          .to eq({
+                   '[1, 0, "a"]' => 1,
+                   '[0, 0, "ab"]' => 2,
+                   '[0, 0, "ba"]' => 2,
+                   '[0, 0, "ac"]' => 1,
+                   '[0, 0, "ca"]' => 1,
+                   '[0, 1, "a"]' => 1
+                 })
+      end
+    end
   end
 
   context '#levenshtein_distance' do


### PR DESCRIPTION
This PR adds support for computing the cosine similarity using n-grams of the strings. The old behavior is equivalent to using 1-grams. Example from the provided specs:
```ruby
it 'returns correct 2-gram similarity' do
  # here _ is substitution for the pad symbol
  # abc has bigrams: _a, ab, bc, c_
  # abcacbc has bigrams: _a, ab, bc, ca, ac, cb, bc, c_

  expect(klass.cosine('abc', 'abcacbc',
                      ngram: 2)).to be_within(0.001).of(0.79)
end
```

Maybe it can be documented more.

Anyway, would be happy to receive any feedback :)